### PR TITLE
Improves handling of build options and makes package compatible with Unity Package Manager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.9] - 2020-03-07
+### Added
+- Added support for Android ARM64 architecture.
+- Added support for APK splitting in Android.
+
+### Changed
+- Updated to iOS build platform work by @chloethompson to support changes.
+- Improve handling of build options [PR #42](https://github.com/Chaser324/unity-build/pull/42/commits/e7cfee053255e5248784a6da96a36e89506ccf9f).
+
+### Removed
+- Removed obsolete code in BuildProject.cs and BuildReleaseTypeDrawer.cs.
+- Removed obsolete Linux build architectures on 2019.2+.
+
+### Fixed
+- Fixed an issue where custom defines were overwrite when build was finished.
+- Fixed issue in Linux build name moving binaryName to BuildArchitecture.
+- Fixed UI spacing for Unity 2019.3x [Issue #43](https://github.com/Chaser324/unity-build/issues/43)
+- Restored pre-build player settings after build has finished.
+- Fixed Android device type setting being ignored.
+
+[Unreleased]: https://github.com/Chaser324/unity-build/compare/v0.9.9...HEAD
+[0.9.9]: https://github.com/Chaser324/unity-build/compare/v0.9.8...v0.9.9)

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4e7427d0dee5e65418a1b100bbcdc3f1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -29,7 +29,7 @@ public static class BuildProject
         PerformBuild(buildConfigs);
     }
 
-    public static void BuildSingle(string keyChain, BuildOptions options = BuildOptions.None)
+    public static void BuildSingle(string keyChain, BuildOptions options)
     {
         string[] buildConfigs = new string[] { keyChain };
         PerformBuild(buildConfigs, options);
@@ -324,13 +324,8 @@ public static class BuildProject
     {
         bool success = true;
 
-        // Get build options.
-        if (releaseType.developmentBuild)
-            options |= BuildOptions.Development;
-        if (releaseType.allowDebugging)
-            options |= BuildOptions.AllowDebugging;
-        if (releaseType.enableHeadlessMode)
-            options |= BuildOptions.EnableHeadlessMode;
+        if (options == BuildOptions.None)
+            options = releaseType.buildOptions;
 
         // Generate build path.
         string buildPath = GenerateBuildPath(BuildSettings.basicSettings.buildPath, releaseType, platform, architecture, distribution, buildTime);

--- a/Editor/Build/Settings/BuildReleaseType.cs
+++ b/Editor/Build/Settings/BuildReleaseType.cs
@@ -13,9 +13,7 @@ public class BuildReleaseType
     public string companyName = string.Empty;
     public string productName = string.Empty;
 
-    public bool developmentBuild = false;
-    public bool allowDebugging = false;
-    public bool enableHeadlessMode = false;
+    public BuildOptions buildOptions;
     public string customDefines = string.Empty;
 
     public SceneList sceneList = new SceneList();

--- a/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
+++ b/Editor/Build/Settings/UI/BuildReleaseTypeDrawer.cs
@@ -45,21 +45,27 @@ public class BuildReleaseTypeDrawer : PropertyDrawer
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("customDefines"));
 
-            SerializedProperty developmentBuild = property.FindPropertyRelative("developmentBuild");
-            SerializedProperty allowDebugging = property.FindPropertyRelative("allowDebugging");
-            SerializedProperty enableHeadlessMode = property.FindPropertyRelative("enableHeadlessMode");
+            SerializedProperty buildOptions = property.FindPropertyRelative("buildOptions");
+            
+            bool enableHeadlessMode = ((BuildOptions)buildOptions.intValue & BuildOptions.EnableHeadlessMode) == BuildOptions.EnableHeadlessMode;
+            bool developmentBuild = ((BuildOptions)buildOptions.intValue & BuildOptions.Development) == BuildOptions.Development;
+            bool allowDebugging = ((BuildOptions)buildOptions.intValue & BuildOptions.AllowDebugging) == BuildOptions.AllowDebugging;
+            
+            enableHeadlessMode = EditorGUILayout.ToggleLeft(" Server Build", enableHeadlessMode);
+            if (enableHeadlessMode) buildOptions.intValue |= (int)BuildOptions.EnableHeadlessMode;
+            else buildOptions.intValue &= ~(int)BuildOptions.EnableHeadlessMode;
+            
+            developmentBuild = EditorGUILayout.ToggleLeft(" Development Build", developmentBuild);
+            if (developmentBuild) buildOptions.intValue |= (int)BuildOptions.Development;
+            else buildOptions.intValue &= ~(int)BuildOptions.Development;
 
-            EditorGUI.BeginDisabledGroup(enableHeadlessMode.boolValue);
-            developmentBuild.boolValue = EditorGUILayout.ToggleLeft(" Development Build", developmentBuild.boolValue);
+            EditorGUI.BeginDisabledGroup(!developmentBuild);
+            allowDebugging = EditorGUILayout.ToggleLeft(" Script Debugging", allowDebugging);
             EditorGUI.EndDisabledGroup();
-
-            EditorGUI.BeginDisabledGroup(!developmentBuild.boolValue);
-            allowDebugging.boolValue = EditorGUILayout.ToggleLeft(" Script Debugging", allowDebugging.boolValue);
-            EditorGUI.EndDisabledGroup();
-
-            EditorGUI.BeginDisabledGroup(developmentBuild.boolValue);
-            enableHeadlessMode.boolValue = EditorGUILayout.ToggleLeft(" Headless Mode", enableHeadlessMode.boolValue);
-            EditorGUI.EndDisabledGroup();
+            if (allowDebugging) buildOptions.intValue |= (int)BuildOptions.AllowDebugging;
+            else buildOptions.intValue &= ~(int)BuildOptions.AllowDebugging;
+            
+            buildOptions.intValue = (int)(BuildOptions)EditorGUILayout.EnumFlagsField("Advanced", (BuildOptions)buildOptions.intValue);
 
             EditorGUILayout.PropertyField(property.FindPropertyRelative("sceneList"));
 

--- a/Editor/Build/Settings/UI/ProjectConfigurationsDrawer.cs
+++ b/Editor/Build/Settings/UI/ProjectConfigurationsDrawer.cs
@@ -110,6 +110,7 @@ public class ProjectConfigurationsDrawer : PropertyDrawer
                     BuildPlatform platform;
                     BuildArchitecture arch;
                     BuildDistribution dist;
+                    BuildOptions buildOptions = BuildOptions.None;
 
                     bool parseSuccess = BuildSettings.projectConfigurations.ParseKeychain(selectedKeyChain.stringValue, out releaseType, out platform, out arch, out dist);
 
@@ -123,6 +124,7 @@ public class ProjectConfigurationsDrawer : PropertyDrawer
 
                         if (releaseType != null)
                         {
+                            buildOptions = releaseType.buildOptions;
                             EditorGUILayout.LabelField("Release Type", UnityBuildGUIUtility.midHeaderStyle);
                             EditorGUILayout.LabelField("Type Name:\t" + releaseType.typeName);
                             
@@ -154,20 +156,26 @@ public class ProjectConfigurationsDrawer : PropertyDrawer
                         GUI.backgroundColor = Color.green;
                         if (GUILayout.Button("Build", GUILayout.ExpandWidth(true)))
                         {
+                            BuildOptions finalBuildOptions = buildOptions;
                             EditorApplication.delayCall += () =>
-                                BuildProject.BuildSingle(selectedKeyChain.stringValue);
+                                BuildProject.BuildSingle(selectedKeyChain.stringValue, finalBuildOptions);
                         }
                         if (GUILayout.Button("Build and Run", GUILayout.ExpandWidth(true)))
                         {
+                            buildOptions |= BuildOptions.AutoRunPlayer;
+                            BuildOptions finalBuildOptions = buildOptions;
                             EditorApplication.delayCall += () =>
-                                BuildProject.BuildSingle(selectedKeyChain.stringValue, BuildOptions.AutoRunPlayer);
+                                BuildProject.BuildSingle(selectedKeyChain.stringValue, finalBuildOptions);
                         }
 
-                        EditorGUI.BeginDisabledGroup(!releaseType.developmentBuild);
+                        EditorGUI.BeginDisabledGroup((buildOptions & BuildOptions.Development) != BuildOptions.Development);
                         if (GUILayout.Button("Build and Run w/ Profiler", GUILayout.ExpandWidth(true)))
                         {
+                            buildOptions |= BuildOptions.AutoRunPlayer;
+                            buildOptions |= BuildOptions.ConnectWithProfiler;
+                            BuildOptions finalBuildOptions = buildOptions;
                             EditorApplication.delayCall += () =>
-                                BuildProject.BuildSingle(selectedKeyChain.stringValue, BuildOptions.AutoRunPlayer | BuildOptions.ConnectWithProfiler);
+                                BuildProject.BuildSingle(selectedKeyChain.stringValue, finalBuildOptions);
                         }
                         EditorGUI.EndDisabledGroup();
                         GUI.backgroundColor = defaultBackgroundColor;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Requires Unity 5.0 or higher. Currently supports Windows, OSX, and Linux builds 
 
 ### Install
 
-Either [download the latest released Unity Package][release] and import it into your project OR [download the zip][download] of this repository and extract its contents into your Unity project's Assets directory.
+ You can [add the link from our git repository](https://github.com/Chaser324/unity-build.git) and load this package using [Unity Package Manager](https://docs.unity3d.com/Packages/com.unity.package-manager-ui@2.0/manual/index.html), you can also [download the latest released Unity Package][release] and import it into your project OR [download the zip][download] of this repository and extract its contents into your Unity project's Assets directory.
 
 You may also want to download some of the available BuildAction modules in the [Unity-Build-Actions][unitybuild-actions] repository to expand SuperUnityBuild's capabilities.
 

--- a/definitions.asmdef
+++ b/definitions.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "com.SuperSystems.UnityBuild",
+    "rootNamespace": "",
+    "references": [
+        "GUID:69448af7b92c7f342b298e06a37122aa"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/definitions.asmdef.meta
+++ b/definitions.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf7b7d9340660ea4495e1f45f0fc349d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.supersystems.unitybuild",
+  "displayName": "Super Unity Build",
+  "version": "0.9.9",
+  "unity": "2019.1",
+  "description": "Super Unity Build is a Unity utility that automates the process of generating builds of your game. It's easy and quick enough to use on small games, but it's also powerful and extensible enough to be extremely useful on larger projects. The key to this flexibility lies in Super Unity Builds configurable degrees of granularity and its BuildActions framework which allows additional operations to be added into the build process.",
+  "documentationUrl": "https://github.com/Chaser324/unity-build/wiki",
+  "type": "tool"
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd554a204cfd38f4986eb4eef10fbe17
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I've resolved the merging conflict in PR #42 from @rthery and it is properly merged and working. In my humble opinion, this contribution from rthery is an important enhancement given the changing nature of Unity over the years. 

On the other hand, I would like to point out that [Unity Package Manager](https://docs.unity3d.com/Packages/com.unity.package-manager-ui@2.0/manual/index.html) is the most convenient way of importing tools into our projects and it can be load packages directly from Github.

In order to make this project an Unity package compatible with the manager I've added the manifest file called package.json, the assembly definitions and the changelog, containing the last changes in the master branch since the last released published in 2018, if I'm not in mistake - please take a look since I'm not English native and some things could be rewrite to max comprehension, although the text is based on commits. Since for the moment the current state of unity-build seems to be working properly, even in the lasts Unity versions, and given the time it has not been versioned with the new bugfixes pushed to the repository, I suggest setting this commit as the foundation for version 0.9.9. 

![8KXelzfp08](https://user-images.githubusercontent.com/646383/110240310-34c82380-7f43-11eb-946d-8a4b0da17c6f.png)
