### PR TITLE
Fixed: open build folder fails w/bad slashes

### DIFF
--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -389,7 +389,7 @@ namespace SuperUnityBuild.BuildTool
             // Open output folder if option is enabled.
             if (BuildSettings.basicSettings.openFolderPostBuild)
             {
-                string outputFolder = BuildSettings.basicSettings.baseBuildFolder;
+                string outputFolder = Path.GetFullPath(BuildSettings.basicSettings.baseBuildFolder);
 
                 try
                 {

--- a/Editor/Build/Platform/BuildIOS.cs
+++ b/Editor/Build/Platform/BuildIOS.cs
@@ -43,7 +43,11 @@ namespace SuperUnityBuild.BuildTool
                 variants = new BuildVariant[] {
                     new BuildVariant(_deviceTypeVariantId, EnumNamesToArray<iOSTargetDevice>(), 0),
                     new BuildVariant(_sdkVersionVariantId, EnumNamesToArray<iOSSdkVersion>(true), 0),
+                    #if UNITY_2021_2_OR_NEWER
+                    new BuildVariant(_buildConfigTypeVariantId, EnumNamesToArray<XcodeBuildConfig>(), 0),
+                    #else
                     new BuildVariant(_buildConfigTypeVariantId, EnumNamesToArray<iOSBuildType>(), 0),
+                    #endif
                 };
             }
         }
@@ -71,7 +75,11 @@ namespace SuperUnityBuild.BuildTool
 
         private void SetBuildConfigType(string key)
         {
+            #if UNITY_2021_2_OR_NEWER
+            EditorUserBuildSettings.iOSXcodeBuildConfig = EnumValueFromKey<XcodeBuildConfig>(key);
+            #else
             EditorUserBuildSettings.iOSBuildConfigType = EnumValueFromKey<iOSBuildType>(key);
+            #endif
         }
 
         private void SetDeviceType(string key)

--- a/Editor/Build/Settings/UI/BasicSettingsDrawer.cs
+++ b/Editor/Build/Settings/UI/BasicSettingsDrawer.cs
@@ -54,7 +54,7 @@ namespace SuperUnityBuild.BuildTool
 
                 if (GUILayout.Button("Open Build Folder", GUILayout.ExpandWidth(true)))
                 {
-                    string path = BuildSettings.basicSettings.baseBuildFolder;
+                    string path = Path.GetFullPath(BuildSettings.basicSettings.baseBuildFolder);
                     if (!Directory.Exists(path))
                         Directory.CreateDirectory(path);
 


### PR DESCRIPTION
There are two places where we use System.Diagnostics.Process.Start to open an explorer window in the build folder: with an explicit button in the build window, and automatically after a build. On Windows, if the build path was input manually and with forward slashes, this call would fail. Using Path.GetFullPath() circumvents this by converting the given path to a native-compatible format.