### PR TITLE
Review first: Remove .NET Standard 2.1 Dependency & Fix Scripting Restore

### DIFF
--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -375,6 +375,7 @@ namespace SuperUnityBuild.BuildTool
             string preBuildCompanyName = PlayerSettings.companyName;
             string preBuildProductName = PlayerSettings.productName;
             string preBuildBundleIdentifier = PlayerSettings.GetApplicationIdentifier(platform.targetGroup);
+            ScriptingImplementation preBuildImplementation = PlayerSettings.GetScriptingBackend(platform.targetGroup);
 
             // Configure environment settings to match the build configuration
             ConfigureEnvironment(releaseType, platform, architecture, scriptingBackend, distribution, buildTime);
@@ -426,6 +427,7 @@ namespace SuperUnityBuild.BuildTool
             PlayerSettings.companyName = preBuildCompanyName;
             PlayerSettings.productName = preBuildProductName;
             PlayerSettings.SetApplicationIdentifier(platform.targetGroup, preBuildBundleIdentifier);
+            PlayerSettings.SetScriptingBackend(platform.targetGroup, preBuildImplementation);
 
             return success;
         }

--- a/Editor/Build/Platform/BuildAndroid.cs
+++ b/Editor/Build/Platform/BuildAndroid.cs
@@ -93,7 +93,7 @@ namespace SuperUnityBuild.BuildTool
                 variants = new BuildVariant[] {
                     new BuildVariant(_deviceTypeVariantId, EnumNamesToArray<AndroidArchitecture>()
                         .Skip(1)
-                        .SkipLast(1)
+                        .EnumSkipLastElement()
                         .ToArray(),
                     0, true),
                     new BuildVariant(_textureCompressionVariantId, EnumNamesToArray<MobileTextureSubtarget>(), 0),

--- a/Editor/Build/Platform/BuildAndroid.cs
+++ b/Editor/Build/Platform/BuildAndroid.cs
@@ -93,7 +93,7 @@ namespace SuperUnityBuild.BuildTool
                 variants = new BuildVariant[] {
                     new BuildVariant(_deviceTypeVariantId, EnumNamesToArray<AndroidArchitecture>()
                         .Skip(1)
-                        .EnumSkipLastElement()
+                        .SkipLast()
                         .ToArray(),
                     0, true),
                     new BuildVariant(_textureCompressionVariantId, EnumNamesToArray<MobileTextureSubtarget>(), 0),

--- a/Editor/Build/Platform/BuildVariant.cs
+++ b/Editor/Build/Platform/BuildVariant.cs
@@ -24,7 +24,7 @@ namespace SuperUnityBuild.BuildTool
         {
             get
             {
-                return isFlag ? string.Join('+', flags) : values[selectedIndex];
+                return isFlag ? string.Join("+", flags) : values[selectedIndex];
             }
         }
 
@@ -64,7 +64,7 @@ namespace SuperUnityBuild.BuildTool
 
         public override string ToString()
         {
-            return isFlag ? string.Join('+', flags) : values[selectedIndex];
+            return isFlag ? string.Join("+", flags) : values[selectedIndex];
         }
     }
 }

--- a/Editor/Generic/ExtensionMethods.cs
+++ b/Editor/Generic/ExtensionMethods.cs
@@ -1,6 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Collections.Generic;
 using UnityEditor;
 
 namespace SuperUnityBuild.BuildTool
@@ -72,17 +72,16 @@ namespace SuperUnityBuild.BuildTool
                 value.DeleteArrayElementAtIndex(i);
         }
 
-        //Provided by Jon Skeet in https://stackoverflow.com/questions/969091/c-skiplast-implementation
-        public static IEnumerable<T> EnumSkipLastElement<T>(this IEnumerable<T> source)
+        // Provided by Jon Skeet in https://stackoverflow.com/questions/969091/c-skiplast-implementation
+        public static IEnumerable<T> SkipLast<T>(this IEnumerable<T> source)
         {
             T previous = default(T);
             bool first = true;
             foreach (T element in source)
             {
                 if (!first)
-                {
                     yield return previous;
-                }
+
                 previous = element;
                 first = false;
             }

--- a/Editor/Generic/ExtensionMethods.cs
+++ b/Editor/Generic/ExtensionMethods.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 using UnityEditor;
 
 namespace SuperUnityBuild.BuildTool
@@ -69,6 +70,22 @@ namespace SuperUnityBuild.BuildTool
 
             if (value.arraySize == oldLength)
                 value.DeleteArrayElementAtIndex(i);
+        }
+
+        //Provided by Jon Skeet in https://stackoverflow.com/questions/969091/c-skiplast-implementation
+        public static IEnumerable<T> EnumSkipLastElement<T>(this IEnumerable<T> source)
+        {
+            T previous = default(T);
+            bool first = true;
+            foreach (T element in source)
+            {
+                if (!first)
+                {
+                    yield return previous;
+                }
+                previous = element;
+                first = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #111 as mentioned in #112 and also restores scripting backend after build as mentioned in #112. 

Unfortunately since I use 2020.3 I can't even compile to test my other smaller feature branches without including the changes from this PR so the best I can do is to keep this as its own. The other PRs will have merged the commits from this PR but you can safely ignore that; once this is merged they won't appear as file differences I believe. Apologies for that!