### PR TITLE
Generate Build Constants Button

### DIFF
--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -78,6 +78,34 @@ namespace SuperUnityBuild.BuildTool
             );
         }
 
+        /// <summary>
+        /// Ignore the Editor configuration steps and only generate the BuildConstants.cs file,
+        /// to avoid dealing with platform and scene list switching
+        /// </summary>
+        /// <param name="configKey"></param>
+        /// <param name="options"></param>
+        public static void GenerateBuildConstantsOnlyButton(string configKey, BuildOptions options = BuildOptions.None)
+        {
+            DateTime configureTime = DateTime.Now;
+
+            // Clear any old notifications
+            BuildNotificationList.instance.RefreshAll();
+
+            // Report Build Constants generation
+            BuildNotificationList.instance.AddNotification(new BuildNotification(
+                BuildNotification.Category.Notification,
+                "Generating BuildConstants for: ", configKey,
+                true, null));
+
+            // Parse build config
+            BuildSettings.projectConfigurations.ParseKeychain(configKey, out BuildReleaseType releaseType, out BuildPlatform platform, out BuildArchitecture architecture,
+                out BuildScriptingBackend scriptingBackend, out BuildDistribution distribution);
+            string constantsFileLocation = BuildSettings.basicSettings.constantsFileLocation;
+
+            GenerateBuildConstants(releaseType, platform, architecture, scriptingBackend, distribution, configureTime, constantsFileLocation);
+
+        }
+
         public static string GenerateDefaultDefines(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture arch,
             BuildScriptingBackend scriptingBackend, BuildDistribution dist)
         {
@@ -263,6 +291,14 @@ namespace SuperUnityBuild.BuildTool
 
             // Refresh scene list to make sure nothing has been deleted or moved
             releaseType.sceneList.Refresh();
+        }
+
+        ///Create the buildConstants.cs file
+        private static void GenerateBuildConstants(BuildReleaseType releaseType, BuildPlatform platform, BuildArchitecture architecture,
+            BuildScriptingBackend scriptingBackend, BuildDistribution distribution, DateTime buildTime, string constantsFileLocation)
+        {
+            BuildConstantsGenerator.Generate(buildTime, constantsFileLocation, BuildSettings.productParameters.buildVersion,
+                releaseType, platform, scriptingBackend, architecture, distribution);
         }
 
         private static void ReplaceFromFile(StringBuilder sb, string keyString, string filename)

--- a/Editor/Build/Settings/UI/ProjectConfigurationsDrawer.cs
+++ b/Editor/Build/Settings/UI/ProjectConfigurationsDrawer.cs
@@ -182,6 +182,12 @@ namespace SuperUnityBuild.BuildTool
                             }
                             EditorGUI.EndDisabledGroup();
 
+                            if (GUILayout.Button(new GUIContent("Generate Build Constants", "Only generate the BuildConstants.cs file without changing platform."), GUILayout.ExpandWidth(true)))
+                            {
+                                // Generate the Build Constants File
+                                BuildProject.GenerateBuildConstantsOnlyButton(selectedKeyChain.stringValue, buildOptions);
+                            }
+
                             if (GUILayout.Button(new GUIContent("Configure Editor Environment", "Switches platform, refreshes BuildConstants, applies scripting defines and variant settings and sets Build Settings scene list to match the selected build configuration"), GUILayout.ExpandWidth(true)))
                             {
                                 // Update Editor environment settings to match selected build configuration


### PR DESCRIPTION
Hi, this is the first of a series of improvements I've been playing around with in my fork. This addition allows users to press a button to generate the BuildConstants file for a selected build without automatically matching their Editor settings (such as the build scenes, product name, etc.) to the selected build:

![image](https://github.com/superunitybuild/buildtool/assets/11141862/bca813c4-d99a-421a-a056-f63f2d9a09ab)

In order to create this commit, I cherry-picked the feature out of my dev branch and squashed it down. Coincidentally, this commit would've also added the scripting backend and "Generated" namespace to the BuildConstants file but I saw that it was already completed independently! It was a really similar implementation to how I was doing it, so I conformed to the approach used in the base project. I will also try and backport this and the other recent changes into my fork for easier cross-compatibility and git comparisons in the future.

As always, let me know if you have any suggestions or concerns and I'm happy to make any updates needed. Thanks!