### PR TITLE
Add buildCounter in BuildConstants

### DIFF
--- a/Editor/Build/BuildProject.cs
+++ b/Editor/Build/BuildProject.cs
@@ -242,7 +242,7 @@ namespace SuperUnityBuild.BuildTool
 
             // Generate BuildConstants
             BuildConstantsGenerator.Generate(buildTime, constantsFileLocation, BuildSettings.productParameters.buildVersion,
-                releaseType, platform, scriptingBackend, architecture, distribution);
+                BuildSettings.productParameters.buildCounter, releaseType, platform, scriptingBackend, architecture, distribution);
 
             // Refresh scene list to make sure nothing has been deleted or moved
             releaseType.sceneList.Refresh();

--- a/Editor/BuildConstantsGenerator.cs
+++ b/Editor/BuildConstantsGenerator.cs
@@ -39,6 +39,7 @@ namespace SuperUnityBuild.BuildTool
             DateTime buildTime,
             string filePath = "",
             string currentVersion = "",
+            int currentBuildCounter = 0,
             BuildReleaseType currentReleaseType = null,
             BuildPlatform currentBuildPlatform = null,
             BuildScriptingBackend currentScriptingBackend = null,
@@ -232,6 +233,7 @@ namespace SuperUnityBuild.BuildTool
                 // Write current values.
                 writer.WriteLine("        public static readonly DateTime buildDate = new DateTime({0});", buildTime.Ticks);
                 writer.WriteLine("        public const string version = \"{0}\";", versionString);
+                writer.WriteLine("        public const int buildCounter = {0};", currentBuildCounter);
                 writer.WriteLine("        public const ReleaseType releaseType = ReleaseType.{0};", releaseTypeString);
                 writer.WriteLine("        public const Platform platform = Platform.{0};", platformString);
                 writer.WriteLine("        public const ScriptingBackend scriptingBackend = ScriptingBackend.{0};", scriptingBackendString);


### PR DESCRIPTION
I want to show androidBundleVersionCode in the game ui but i cannot get version code in runtime.
Basically my bundle version code is the same as buildCounter. Then why not just do this?. :blush: