### PR TITLE
Fix useAPKExpansionFiles obsolete problem

### DIFF
--- a/Editor/Build/Platform/BuildAndroid.cs
+++ b/Editor/Build/Platform/BuildAndroid.cs
@@ -152,7 +152,11 @@ namespace SuperUnityBuild.BuildTool
         {
             ApkExpansionFilesType expansionFilesType = EnumValueFromKey<ApkExpansionFilesType>(key);
 
+#if UNITY_2023_1_OR_NEWER
+            PlayerSettings.Android.splitApplicationBinary = expansionFilesType == ApkExpansionFilesType.SplitAppBinary;
+#else
             PlayerSettings.Android.useAPKExpansionFiles = expansionFilesType == ApkExpansionFilesType.SplitAppBinary;
+#endif
         }
 
         private void SetBinaryType(string key)


### PR DESCRIPTION
The API `PlayerSettings.Android.useAPKExpansionFiles` has changed to `PlayerSettings.Android.splitApplicationBinary` since 2023.1