### PR TITLE
SanitizeDefine fix for different cultures.

### DIFF
--- a/Editor/Build/Action/BuildFilter.cs
+++ b/Editor/Build/Action/BuildFilter.cs
@@ -107,7 +107,7 @@ namespace SuperUnityBuild.BuildTool
             {
                 bool success = false;
 
-                test = test.Trim().ToUpper();
+                test = test.Trim().ToUpperInvariant();
 
                 switch (type)
                 {
@@ -140,9 +140,9 @@ namespace SuperUnityBuild.BuildTool
                     case FilterComparison.NotEqual:
                         return !(targetString.Equals(test, StringComparison.OrdinalIgnoreCase));
                     case FilterComparison.Contains:
-                        return targetString.ToUpper().Contains(test);
+                        return targetString.ToUpperInvariant().Contains(test);
                     case FilterComparison.DoesNotContain:
-                        return !(targetString.ToUpper().Contains(test));
+                        return !(targetString.ToUpperInvariant().Contains(test));
                     default:
                         return false;
                 }

--- a/Editor/Build/Action/UI/BuildActionListDrawer.cs
+++ b/Editor/Build/Action/UI/BuildActionListDrawer.cs
@@ -28,7 +28,7 @@ namespace SuperUnityBuild.BuildTool
 
             list = property.FindPropertyRelative("buildActions");
 
-            List<Type> actionTypes = property.name.ToUpper().Contains("PRE") ?
+            List<Type> actionTypes = property.name.ToUpperInvariant().Contains("PRE") ?
                 BuildActionListUtility.preBuildActions :
                 BuildActionListUtility.postBuildActions;
 
@@ -146,7 +146,7 @@ namespace SuperUnityBuild.BuildTool
 
         private BuildAction[] GetBuildActionsForProperty(SerializedProperty property)
         {
-            return property.name.ToUpper().Contains("PRE") ?
+            return property.name.ToUpperInvariant().Contains("PRE") ?
                 BuildSettings.preBuildActions.buildActions :
                 BuildSettings.postBuildActions.buildActions;
         }

--- a/Editor/Generic/ExtensionMethods.cs
+++ b/Editor/Generic/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using UnityEditor;
@@ -7,6 +8,8 @@ namespace SuperUnityBuild.BuildTool
 {
     public static class ExtensionMethods
     {
+        private static CultureInfo _culture = new CultureInfo("en-GB");
+
         public static string SanitizeCodeString(this string str)
         {
             str = Regex.Replace(str, "[^a-zA-Z0-9_]", "_", RegexOptions.Compiled);
@@ -19,7 +22,7 @@ namespace SuperUnityBuild.BuildTool
 
         public static string SanitizeDefine(this string input)
         {
-            return input.ToUpper().Replace(" ", "").SanitizeCodeString();
+            return input.ToUpper(_culture).Replace(" ", "").SanitizeCodeString();
         }
 
         public static string SanitizeFolderName(this string folderName)

--- a/Editor/Generic/ExtensionMethods.cs
+++ b/Editor/Generic/ExtensionMethods.cs
@@ -8,7 +8,6 @@ namespace SuperUnityBuild.BuildTool
 {
     public static class ExtensionMethods
     {
-        private static CultureInfo _culture = new CultureInfo("en-GB");
 
         public static string SanitizeCodeString(this string str)
         {
@@ -22,7 +21,7 @@ namespace SuperUnityBuild.BuildTool
 
         public static string SanitizeDefine(this string input)
         {
-            return input.ToUpper(_culture).Replace(" ", "").SanitizeCodeString();
+            return input.ToUpperInvariant().Replace(" ", "").SanitizeCodeString();
         }
 
         public static string SanitizeFolderName(this string folderName)

--- a/Editor/Generic/TokensUtility.cs
+++ b/Editor/Generic/TokensUtility.cs
@@ -117,7 +117,7 @@ namespace SuperUnityBuild.BuildTool
 
                     while (index > -1)
                     {
-                        string noun = lines[UnityEngine.Random.Range(0, lines.Length - 1)].ToUpper();
+                        string noun = lines[UnityEngine.Random.Range(0, lines.Length - 1)].ToUpperInvariant();
 
                         sb.Replace(token, noun, index, token.Length);
 


### PR DESCRIPTION
Used en-GB culture info in ToUpper method.
Lets say we want to convert "Android" to upper case. Without a cultureinfo, ToUpper method uses local computer's culture info. For example for Turkish Android is converted to ANDROİD. This was causing in scripting defines in player settings.

Before Fix:
![before](https://github.com/superunitybuild/buildtool/assets/34743525/0615cb70-a6e1-4cc5-b3d7-3a198a5d7759)
After Fix:
![after](https://github.com/superunitybuild/buildtool/assets/34743525/1332669c-3c29-4ad7-b324-f9667174fea5)

